### PR TITLE
Kubernetes prepare

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,87 @@
 # kaperusov_platform
 kaperusov Platform repository
+
+## ДЗ №1
+
+### Задание №1
+
+> Разберитесь почему все pod в namespace kube-system восстановились после удаления. Укажите причину в описании PR
+
+Несколько причин. 
+
+Для coredns это наличие контроллера репликаций, в лице coredns deployement, 
+который следит за количеством реплик в кластере и пытается восстановить их если они уменьшаются. 
+Например, если выполнить команду `kubectl describe deploy -n kube-system coredns`
+мы можем увидеть подобное сообщение
+`NewReplicaSet:   coredns-565d847f94 (1/1 replicas created)`
+
+kube-apiserver запускается как статический pod, которыми напрямую управляет kubelet daemon читая
+их конфигурации из директории `/etc/kubernetes/manifests/`, там можно найти такие файлы: 
+  - etcd.yaml
+  - kube-apiserver.yaml 
+  - kube-controller-manager.yaml
+  - kube-scheduler.yaml
+
+Эти конфигурации создаются при инициализации кластера, после чего kubelet daemon постояно следит 
+за изменениями в них и пересоздаёт в случае обнаружения изменений, а также восстанавливает, если поды 
+по каким-то причинам были остановлены. 
+
+### Содержимое проекта
+
+#### web/
+
+В папке web находится тестовый проект созданый с помощью [Hugo](https://gohugo.io/), в котором я тренировался 
+с запуском своего web-сервера на порту 8000 следуюя инструкциям ДЗ (стр.17).
+
+Образ полученный из файла web/Dockerfile загружен в мой [Docker Hub](https://hub.docker.com/repository/docker/kaperusov/kuber-2022-12/general) 
+в тэги 0.0.1 и 0.0.2.
+
+#### app/
+
+В папке app находится совсем простой образ с [nginx](https://hub.docker.com/r/nginxinc/nginx-unprivileged), 
+в который я поместил тестовую статическую HTML страницу, а также использовал его 
+для работы с Init контейнером.
+
+Для запуска нужно воспользоваться следующими командами:
+
+```shell
+kubectl apply -f kubernetes-intro/web-pod.yaml
+kubectl port-forward --address 0.0.0.0 pod/web 8080:8080
+```
+
+После чего перейти по ссылке: [localhost:8080](localhost:8080)
+
+### Задание со ⭐
+
+> Выясните причину, по которой pod frontend находится в статусе Error
+
+Проблема в том, что при формировании yaml файла с помощью команды:
+
+```shell
+kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run -o yaml > frontend-pod-healthy.yaml
+```
+
+в полученном манифесте отсутствуют переменные окружения, необходимые для работы контейнера.
+
+Добавление в манифест недостающей секции `env` исправило ошибку: 
+
+```yaml
+    env:
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+```
+

--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,0 +1,5 @@
+# FROM nginx:latest
+FROM nginxinc/nginx-unprivileged
+
+COPY test.html /usr/share/nginx/html
+USER 1001

--- a/app/test.html
+++ b/app/test.html
@@ -1,0 +1,6 @@
+<html>
+  <head><title>Hello World</title></head>
+  <body>
+    <p>Test page static page.</p>
+  </body>
+</html>

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: avtandilko/hipster-frontend:v0.0.1
+    name: frontend
+    resources: {}
+    env:
+      - name: PORT
+        value: "8080"
+      - name: PRODUCT_CATALOG_SERVICE_ADDR
+        value: "productcatalogservice:3550"
+      - name: CURRENCY_SERVICE_ADDR
+        value: "currencyservice:7000"
+      - name: CART_SERVICE_ADDR
+        value: "cartservice:7070"
+      - name: RECOMMENDATION_SERVICE_ADDR
+        value: "recommendationservice:8080"
+      - name: SHIPPING_SERVICE_ADDR
+        value: "shippingservice:50051"
+      - name: CHECKOUT_SERVICE_ADDR
+        value: "checkoutservice:5050"
+      - name: AD_SERVICE_ADDR
+        value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -7,6 +7,26 @@ metadata:
     server: hugo
 spec: 
   containers:
+    # - 
+    #   image: kaperusov/kuber-2022-12:0.0.2
+    #   name: web-app
     - 
-      image: kaperusov/kuber-2022-12:0.0.2
-      name: web-app
+      image: kaperusov/kuber-2022-12:0.0.2-nginx
+      name: nginx
+      volumeMounts:
+      - mountPath: /usr/share/nginx/html
+        name: app
+
+  initContainers:
+    - 
+      name: init-web-app
+      image: busybox:1.31.0
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+      - mountPath: /app
+        name: app
+
+  volumes:
+  - name: app
+    emptyDir:
+      sizeLimit: 50Mi


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [x] Основное ДЗ
> Разберитесь почему все pod в namespace kube-system восстановились после удаления. Укажите причину в описании PR

Несколько причин. 

Для coredns это наличие контроллера репликаций, в лице coredns deployement, 
который следит за количеством реплик в кластере и пытается восстановить их если они уменьшаются. 
Например, если выполнить команду `kubectl describe deploy -n kube-system coredns`
мы можем увидеть подобное сообщение
`NewReplicaSet:   coredns-565d847f94 (1/1 replicas created)`

kube-apiserver запускается как статический pod, которыми напрямую управляет kubelet daemon читая
их конфигурации из директории `/etc/kubernetes/manifests/`, там можно найти такие файлы: 
  - etcd.yaml
  - kube-apiserver.yaml 
  - kube-controller-manager.yaml
  - kube-scheduler.yaml

Эти конфигурации создаются при инициализации кластера, после чего kubelet daemon постояно следит 
за изменениями в них и пересоздаёт в случае обнаружения изменений, а также восстанавливает, если поды 
по каким-то причинам были остановлены. 

 - [x] Задание со *
> Выясните причину, по которой pod frontend находится в статусе Error

Проблема в том, что при формировании yaml файла с помощью команды:

```shell
kubectl run frontend --image avtandilko/hipster-frontend:v0.0.1 --restart=Never --dry-run -o yaml > frontend-pod-healthy.yaml
```
в полученном манифесте отсутствуют переменные окружения, необходимые для работы контейнера.

Добавление в манифест недостающей секции `env` исправило ошибку: 

```yaml
    env:
      - name: PORT
        value: "8080"
      - name: PRODUCT_CATALOG_SERVICE_ADDR
        value: "productcatalogservice:3550"
      - name: CURRENCY_SERVICE_ADDR
        value: "currencyservice:7000"
      - name: CART_SERVICE_ADDR
        value: "cartservice:7070"
      - name: RECOMMENDATION_SERVICE_ADDR
        value: "recommendationservice:8080"
      - name: SHIPPING_SERVICE_ADDR
        value: "shippingservice:50051"
      - name: CHECKOUT_SERVICE_ADDR
        value: "checkoutservice:5050"
      - name: AD_SERVICE_ADDR
        value: "adservice:9555"
```

## В процессе сделано:
 - kubernetes-intro/web-pod.yaml манифест для NGINX приложения
 - kubernetes-intro/frontend-pod-healthy.yaml исправленный манифест для задания со звёздочкой

## Как запустить проект:

Для запуска нужно воспользоваться следующими командами:

```shell
kubectl apply -f kubernetes-intro/web-pod.yaml
kubectl port-forward --address 0.0.0.0 pod/web 8080:8080
```

## Как проверить работоспособность:
 - Перейти по ссылке http://localhost:8080

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
